### PR TITLE
Adds templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,33 @@
-# .github
-Organization wide repository.
+# CDAT .github
+
+This repository contains Github Action workflows and custom actions.
+
+# Useful links
+
+- [GitHub actions](https://docs.github.com/en/actions)
+- [GitHub actions repo](https://github.com/actions)
+- [Using workflow templates](https://docs.github.com/en/actions/configuring-and-managing-workflows/sharing-workflow-templates-within-your-organization#using-a-workflow-template)
+
+# Templates
+
+## First interactions
+
+This workflow will comment on new issue/pr when it's a users first time contributing.
+
+There are two customizable fields.
+
+- issue-message
+- pr-message
+
+### Example
+```yaml
+issue-message: |
+  Thank you for opening this issues.
+
+  Here are some resources:
+  - [CDAT](https://cdat.llnl.gov)
+```
+
+## Stale issues
+
+This workflow will scan issues and PRs for 30 days of inactivity and label them stale.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This repository contains Github Action workflows and custom actions.
 
 ## First interactions
 
-This workflow will comment on new issue/pr when it's a users first time contributing.
+This workflow will comment on new issue/PR when it's a user's first time contributing.
 
 There are two customizable fields.
 
@@ -22,7 +22,7 @@ There are two customizable fields.
 ### Example
 ```yaml
 issue-message: |
-  Thank you for opening this issues.
+  Thank you for opening this issue.
 
   Here are some resources:
   - [CDAT](https://cdat.llnl.gov)

--- a/workflow-templates/interaction.properties.json
+++ b/workflow-templates/interaction.properties.json
@@ -1,0 +1,12 @@
+{
+  "name": "First interaction",
+  "description": "Template for first interaction",
+  "categories": [
+    "Python",
+    "Javascript",
+    "Typescript",
+    "C",
+    "C++",
+    "Go"
+  ]
+}

--- a/workflow-templates/interaction.yml
+++ b/workflow-templates/interaction.yml
@@ -1,0 +1,15 @@
+name: "First interaction"
+
+on:
+  issues:
+    types: [opened]
+  pull_request:
+    types: [opened]
+
+jobs:
+  interaction:
+    steps:
+    - uses: actions/first-interaction@v1
+      repo-token: ${{ secrets.GITHUB_TOKEN }}
+      issues-message: ''
+      pr-message: ''

--- a/workflow-templates/stale.poperties.json
+++ b/workflow-templates/stale.poperties.json
@@ -1,0 +1,12 @@
+{
+  "name": "Mark stale issues",
+  "description": "Template for marking stale issues.",
+  "categories": [
+    "Python",
+    "Javascript",
+    "Typescript",
+    "C",
+    "C++",
+    "Go"
+  ]
+}

--- a/workflow-templates/stale.yml
+++ b/workflow-templates/stale.yml
@@ -12,7 +12,7 @@ jobs:
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'Marking issue as stale, since there has been no activity in 30 days. This issue will be closed unless it is updated or the "stale" label is removed.'
-        stale-pr-message: 'Marking PR as stale, since there has been no activity in 30 days. This issue will be closed unless it is updated or the "stale" label is removed.'
+        stale-pr-message: 'Marking PR as stale, since there has been no activity in 30 days. This PR will be closed unless it is updated or the "stale" label is removed.'
         close-issue-message:
         close-pr-message:
         days-before-stale: 30

--- a/workflow-templates/stale.yml
+++ b/workflow-templates/stale.yml
@@ -11,14 +11,22 @@ jobs:
     - uses: actions/stale@v3
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        stale-issue-message: 'Marking issue as stale, since there has been no activity in 30 days. This issue will be closed unless it is updated or the "stale" label is removed.'
-        stale-pr-message: 'Marking PR as stale, since there has been no activity in 30 days. This PR will be closed unless it is updated or the "stale" label is removed.'
+        stale-issue-message: |
+          Marking issue as stale, since there has been no activity in 30 days.
+
+          Unless the issue is updated or the 'stale' tag is removed, this issue will be closed in 7 days.
+        stale-pr-message: |
+          Marking PR as stale, since there has been no activity in 30 days.
+
+          Unless the PR is updated or the 'stale' tag is removed, this PR will be closed in 7 days.
         close-issue-message:
         close-pr-message:
         days-before-stale: 30
         days-before-close: 7
         stale-issue-label: 'stale'
-        exempt-issue-label: 'needs-triage'
+        # Set to a list of labels that will be exempt from being marked as stale e.g. work-in-progress,kind/bug, etc.
+        exempt-issue-label: 
         stale-pr-label: 'stale'
-        exempt-pr-label: 'needs-triage'
+        # Set to a list of labels that will be exempt from being marked as stale e.g. work-in-progress,kind/bug, etc.
+        exempt-pr-label: 
         debug-only: false # Setting to true will enable dry-run

--- a/workflow-templates/stale.yml
+++ b/workflow-templates/stale.yml
@@ -1,0 +1,24 @@
+name: 'Mark and Close stale issues'
+
+on:
+  schedule:
+    - cron: '0 * * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/stale@v3
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'Marking issue as stale, since there has been no activity in 30 days. This issue will be closed unless it is updated or the "stale" label is removed.'
+        stale-pr-message: 'Marking PR as stale, since there has been no activity in 30 days. This issue will be closed unless it is updated or the "stale" label is removed.'
+        close-issue-message:
+        close-pr-message:
+        days-before-stale: 30
+        days-before-close: 7
+        stale-issue-label: 'stale'
+        exempt-issue-label: 'needs-triage'
+        stale-pr-label: 'stale'
+        exempt-pr-label: 'needs-triage'
+        debug-only: false # Setting to true will enable dry-run


### PR DESCRIPTION
Just a brief description of GitHub actions. Essentially they're tasks that GithHub will run for you. The tasks can really be written in whatever language you want and can be fairly complex, but there are [limitations](https://docs.github.com/en/actions/getting-started-with-github-actions/about-github-actions#usage-limits). These individual tasks can be combined into workflows. The can be triggered by GitHub events e.g. pull requests, issues, etc. They can also be trigger on a schedule via cron. There's also the concept of templates i.e pre-configured workflows, which this repo will contain. Any workflow stored here will show up when adding an action to any repo under the CDAT organization.

[GitHub Actions](https://docs.github.com/en/actions)

I've added two templates.

- Interaction
  - Comments on users issues/PRs.
- Stale
  - Labels issues/PRs stale after 30 days of inactivity.

Questions?
- Is the wording of the messages good?
- Is 30 days too long or short for stale issues?
- Do we want to automatically close stale issues?
- What default labels would you like exempt from being marked stale (default is needs-triage)?
  - This can still be customized once you add the workflow to a repo, but would be nice to keep labels synchronized between repos.